### PR TITLE
add Dockerfile and instructions on building and usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+# Build our binary
+from golang:1.10 as builder
+RUN go get github.com/skybet/welcomebot
+WORKDIR /go/src/github.com/skybet/welcomebot
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o welcomebot  .
+
+# Build our final image
+FROM alpine:latest
+RUN apk add -U ca-certificates
+COPY --from=builder /go/src/github.com/skybet/welcomebot/welcomebot /welcomebot
+CMD ["/welcomebot"]

--- a/README.md
+++ b/README.md
@@ -21,3 +21,19 @@ How about when someone joins a specific channel?
 > We use Monkeybot in this channel to triage issues, so attact their attention with `@monkeybot help`
 
 Example configs in `config.json`
+
+## Building and usage
+
+You will need a Slack token in order to run this.  Welcomebot expects this to be provided as the environment variable `SLACK_TOKEN`.  You will also need to provide a config.json file in the current directory.  See the example config.json in this repo for what should go into that file.
+
+The easiest way of building and running this is in Docker.  First of all build a Docker container:
+
+```
+docker build -t welcomebot .
+```
+
+And then you can run it as follows:
+
+```
+docker run -v config.json -e SLACK_TOKEN=foo welcomebot
+```


### PR DESCRIPTION
Until we have somewhere to publish the Docker image, this is a good start on providing instructions on building and using welcomebot in Docker.