### PR TITLE
Connect to each channel in PublicResponses automatically.

### DIFF
--- a/welcomebot.go
+++ b/welcomebot.go
@@ -51,6 +51,13 @@ func main() {
 
 Loop:
 	for {
+		for _, v := range config.PublicResponses {
+			_, err := api.JoinChannel(v.Channel)
+			if err != nil {
+				fmt.Println("Error joining public channel: %s", err)
+			}
+		}
+
 		select {
 		case msg := <-rtm.IncomingEvents:
 			switch ev := msg.Data.(type) {

--- a/welcomebot.go
+++ b/welcomebot.go
@@ -10,28 +10,16 @@ import (
 	"github.com/nlopes/slack"
 )
 
-type publicResponse struct {
-	Channel  string `json:"channel"`
-	Raw      bool   `json:"raw_response"`
-	Response string `json:"response"`
-}
-
-type dmResponse struct {
-	Channel  string `json:"channel"`
-	Raw      bool   `json:"raw_response"`
-	Response string `json:"response"`
-}
-
-type ephResponse struct {
+type slackResponse struct {
 	Channel  string `json:"channel"`
 	Raw      bool   `json:"raw_response"`
 	Response string `json:"response"`
 }
 
 type Config struct {
-	PublicResponses []publicResponse `json:"responses"`
-	DmResponses     []dmResponse     `json:"dmresponses"`
-	EphResponses    []ephResponse    `json:"ephresponses"`
+	PublicResponses []slackResponse `json:"responses"`
+	DmResponses     []slackResponse `json:"dmresponses"`
+	EphResponses    []slackResponse `json:"ephresponses"`
 }
 
 var (
@@ -49,14 +37,21 @@ func main() {
 
 	go rtm.ManageConnection()
 
+	// Return a slice of all channels from config.json
+	allChans := getChannelList(config.PublicResponses, config.DmResponses, config.EphResponses)
+	// Because duplicates are possible, make a new slice without duplicates
+	cleanSlice := removeDuplicates(allChans)
+
+	// Range over the cleaned up slice and join channels
+	for _, v := range cleanSlice {
+		_, err := api.JoinChannel(v)
+		if err != nil {
+			log.Errorf("Error joining public channel: %s", err)
+		}
+	}
+
 Loop:
 	for {
-		for _, v := range config.PublicResponses {
-			_, err := api.JoinChannel(v.Channel)
-			if err != nil {
-				fmt.Println("Error joining public channel: %s", err)
-			}
-		}
 
 		select {
 		case msg := <-rtm.IncomingEvents:
@@ -189,4 +184,30 @@ func loadConfig(file string) Config {
 	jsonParser := json.NewDecoder(configFile)
 	jsonParser.Decode(&config)
 	return config
+}
+
+func getChannelList(publicSlice, dmSlice, ephSlice []slackResponse) []string {
+	var newSlice []string
+	for _, v := range publicSlice {
+		newSlice = append(newSlice, v.Channel)
+	}
+	for _, v := range dmSlice {
+		newSlice = append(newSlice, v.Channel)
+	}
+	for _, v := range ephSlice {
+		newSlice = append(newSlice, v.Channel)
+	}
+	return newSlice
+}
+
+func removeDuplicates(channelSlice []string) []string {
+	k := make(map[string]bool)
+	slice := []string{}
+	for _, entry := range channelSlice {
+		if _, value := k[entry]; !value {
+			k[entry] = true
+			slice = append(slice, entry)
+		}
+	}
+	return slice
 }


### PR DESCRIPTION
So this adds the functionality desired from issue #14. 

I am only including PublicResponses in this pull for 2 reasons:
- See if others think this is a reasonable solution.
- I wasn't sure if there would be a realistic possibility of there being channels in PublicResponses that wouldn't be in dmRepsonses and ephResponses. If this can occur, I'll work on a solution to this without re-joining the same channels multiple times.

My testing shows that the bot joins every public channel in config.json, and errors out when a channel is gone / private without closing the program.

Feedback would be great, thanks!